### PR TITLE
Joi v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ npm install joi-nochange --save
 ## Usage
 
 ```js
-var Joi = require('joi'); // require Joi as usual
-require('joi-nochange'); // patch in noChange()
+var Joi = require('joi-nochange'); // require this plugin as Joi
 
 var origObj = {
     id: 'k1773y',
@@ -49,8 +48,5 @@ if (result.error) {
 // object is available at `result.value`
 ```
 
-## The Future of `joi-nochange`
-:warning: `joi-nochange` is not a true plugin. Joi does not have a plugin interface yet (see Joi [issue #577](https://github.com/hapijs/joi/issues/577)), so this module monkey patches itself into Joi. When Joi does implement a plugin model, `joi-nochange` will bump to a new major version.
-
 ## Compatible Joi versions
-As of June 2016, this plugin works with joi versions >=6.0.0 (tests fail due to different error messages) and tests pass with versions >=7.2.3. See [this commit](https://github.com/hapijs/joi/commit/f02369903630eda18cb7d2d47082d2a44fa01efb) for more information on tests failing prior to 7.2.3.
+This plugin works with multiple versions of Joi. For compatibility with Joi >= 9.0.0, use version >= 1.0.0 of this plugin. For compatibility with older versions of Joi, see the `joi-pre-v9` branch of his repo (< 1.0.0).

--- a/index.js
+++ b/index.js
@@ -1,22 +1,48 @@
 'use strict';
 
-var Any = require('joi/lib/any');
-var language = require('joi/lib/language');
-var Hoek = require('hoek');
+const Joi = require('joi');
+const Hoek = require('hoek');
 
-// monkey patch noChange() into Any's prototype
-Any.prototype.noChange = function (sourceObj) {
+// creates a rule for the provided base type
+function createRule(joiType) {
+    const joiBaseType = Joi[joiType];
 
-    return this._test('noChange', null, (value, state, options) => {
+    return {
+        base: joiBaseType(),
+        name: joiType,
+        language: {
+            noChange: 'is not allowed to change' // maybe use 'may not change from {{q}}' instead?
+        },
+        rules: [{
+            name: 'noChange',
+            params: {
+                q: Joi.any()
+            },
+            validate(params, value, state, options) {
 
-        const path = state.path === '' ? null : state.path;
-        const origValue = Hoek.reach(sourceObj, path);
-        if (Hoek.deepEqual(origValue, value)) {
-            return null;
-        }
-        return this.createError('any.noChange', null, state, options);
-    });
-};
+                const path = state.path === '' ? null : state.path;
+                const origValue = Hoek.reach(params.q, path);
 
-// Add any.noChang error message to the language map
-language.errors.any.noChange = 'is not allowed to change';
+                if (Hoek.deepEqual(origValue, value)) {
+                    return null; // Everything is OK
+                }
+
+                return this.createError(joiType + '.noChange', {
+                    v: value//,
+                    // q: origValue
+                }, state, options);
+            }
+        }]
+    };
+}
+
+// extend Joi and export
+// due to extending any() not extending other types, number(), string(), etc. we need to extend all of these manually
+// see https://github.com/hapijs/joi/issues/577
+module.exports = Joi
+    .extend(createRule('any'))
+    .extend(createRule('object'))
+    .extend(createRule('number'))
+    .extend(createRule('string'))
+    .extend(createRule('date'))
+    .extend(createRule('boolean'));

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function createRule(joiType) {
                 const origValue = Hoek.reach(params.q, path);
 
                 if (Hoek.deepEqual(origValue, value)) {
-                    return null; // Everything is OK
+                    return value; // Everything is OK
                 }
 
                 return this.createError(joiType + '.noChange', {

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
   "author": "Mark Herhold",
   "license": "MIT",
   "dependencies": {
-    "hoek": "^3.0.4"
+    "hoek": "^3.0.4",
+    "joi": "9.0.0-6"
   },
   "peerDependencies": {
-    "joi": ">=6.0.0"
+    "joi": ">=9.0.0"
   },
   "devDependencies": {
     "chai": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-nochange",
-  "version": "1.0.0-1",
+  "version": "1.0.0-2",
   "description": "Adds noChange() to Joi",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   "author": "Mark Herhold",
   "license": "MIT",
   "dependencies": {
-    "hoek": "^3.0.4",
-    "joi": "9.0.0-6"
+    "hoek": "^3.0.4"
   },
   "peerDependencies": {
     "joi": ">=9.0.0"
@@ -36,7 +35,7 @@
   "devDependencies": {
     "chai": "3.4.1",
     "eslint": "1.10.3",
-    "joi": "^7.2.2",
+    "joi": "9.0.0-6",
     "mocha": "2.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "chai": "3.4.1",
     "eslint": "1.10.3",
-    "joi": "9.0.0-8",
+    "joi": "9.0.0",
     "mocha": "2.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-nochange",
-  "version": "0.2.0",
+  "version": "1.0.0-0",
   "description": "Adds noChange() to Joi",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "chai": "3.4.1",
     "eslint": "1.10.3",
-    "joi": "9.0.0-6",
+    "joi": "9.0.0-8",
     "mocha": "2.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-nochange",
-  "version": "1.0.0-0",
+  "version": "1.0.0-1",
   "description": "Adds noChange() to Joi",
   "main": "index.js",
   "scripts": {

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var Joi = require('joi');
-require('./../index'); // monkey patch in noChange() to Joi
+var Joi = require('./../index');
 var Hoek = require('hoek');
 var expect = require('chai').expect;
 


### PR DESCRIPTION
Utilizes Joi v9's `extend()` functionality instead of monkey patching.